### PR TITLE
Fix button gradient syntax (remove extra parenthesis)

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@ button {
   margin-top: 15px;
   padding: 12px 25px;
   border: none;
-  background: linear-gradient(to right, rgb(119, 161, 211), rgb(121, 203, 202), rgb(230, 132, 174)););
+  background: linear-gradient(to right, rgb(119, 161, 211), rgb(121, 203, 202), rgb(230, 132, 174));
   color: white;
   font-size: 16px;
   border-radius: 10px;


### PR DESCRIPTION
This PR fixes a minor CSS syntax error in `style.css` where an extra parenthesis was present in the button background gradient.
